### PR TITLE
Use ISO8601 format for JSON date encoding

### DIFF
--- a/Sources/MicroExpress/ServerResponse.swift
+++ b/Sources/MicroExpress/ServerResponse.swift
@@ -156,10 +156,18 @@ public extension ServerResponse {
   
   /// Send a Codable object as JSON to the client.
   func json<T: Encodable>(_ model: T) {
+    let encoder = JSONEncoder()
+    // The default Swift date encoding isn't Javascript
+    // compatible, so pick a more generally accepted
+    // date format.
+    if #available(macOS 10.12, iOS 10.0, *) {
+      encoder.dateEncodingStrategy = .iso8601
+    }
+
     // create a Data struct from the Codable object
     let data : Data
     do {
-      data = try JSONEncoder().encode(model)
+      data = try encoder.encode(model)
     }
     catch {
       return handleError(error)


### PR DESCRIPTION
The default JSONEncoder date encoding is only good if you're client is also Swift (or otherwise Apple library based), as it uses time since 2001 epoch. It's more common for JSON on the web to be ISO8601 encoded.

This PR changes the default encoding to use ISO8601 if it is available. I've tested this on both macOS 12 and Linux, and it works as expected.